### PR TITLE
feat: added details of NSLondon talk at Apple

### DIFF
--- a/Content/times/2024/nslondon.md
+++ b/Content/times/2024/nslondon.md
@@ -1,0 +1,15 @@
+---
+date: 2024-11-21 18:00
+description: Speaker @ NSLondon
+icon: fa-person-chalkboard
+---
+# Speaker
+## NSLondon
+### Nov 2024
+
+
+Presented a talk called ″Check yo device″ for [NSLondon meetup](https://nslondon.com) at **Apple**, Battersea London. 
+
+The talk covered Apple’s [DeviceCheck framework](https://developer.apple.com/documentation/devicecheck), asymmetric cryptography, a [reference implementation of App Attest](https://github.com/Oliver-Binns/app-attest) and some industry standards for client attestation.
+
+[View the slides](https://drive.google.com/file/d/1Bx-3Ts1zYVSgcdLraWfK6gt_nwhoNHWb/view?usp=share_link) | [View the sample code](https://github.com/Oliver-Binns/app-attest)


### PR DESCRIPTION
Added details of NSLondon talk at Apple:
<img width="617" alt="image" src="https://github.com/user-attachments/assets/95525c57-c699-4387-b1e9-1a077160901c">
