### PR TITLE
fix: improve link contrast ratio when in light mode

### DIFF
--- a/Resources/Theme/styles.css
+++ b/Resources/Theme/styles.css
@@ -26,7 +26,10 @@ a, a:hover, a:visited { color: #333; text-decoration: none; }
 h4.year { color: #F9C300; margin-block-start: 0.7em; margin-block-end: 0.7em; }
 .timeline-item p { color: #646464; font-size:12px; }
 .timeline-item p:last-child { margin-bottom: 0; }
-.timeline-item a { color:#F9C300; font-size:12px; }
+.timeline-item a { color:#B38900; font-size:12px; }
+@media (prefers-color-scheme: dark) {
+    .timeline-item a { color:#F9C300; }
+}
 .timeline-item a:hover { text-decoration: underline; }
 .timeline-item i.fas { margin-left:-34px; margin-right:8px; text-align:center; line-height:15px; height:15px; width:15px; padding:5px; background-color:#f9c300; border-radius:50%; color:white; font-size: 12px;  }
 
@@ -55,7 +58,12 @@ footer { padding-bottom:30px; padding-top:10px; }
 }
 
 .post-content a, .post-content a:visited {
-    color:#F9C300;
+    color:#B38900;
+}
+@media (prefers-color-scheme: dark) {
+    .post-content a, .post-content a:visited {
+        color:#F9C300;
+    }
 }
 .post-content a:hover {
     text-decoration:underline;


### PR DESCRIPTION
Links now use a darker colour in light mode which meets WCAG AA 3:1 contrast accessibility requirements.

<img width="938" alt="image" src="https://github.com/user-attachments/assets/8eceb084-c923-4225-b64b-8af062a41727" />
